### PR TITLE
Potential fix for code scanning alert no. 533: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tf_validate_oraclecloud.yml
+++ b/.github/workflows/tf_validate_oraclecloud.yml
@@ -1,5 +1,8 @@
 name: Terraform Oracle Cloud Validate
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/chefgs/terraform_repo/security/code-scanning/533](https://github.com/chefgs/terraform_repo/security/code-scanning/533)

Add an explicit `permissions` block at the workflow root so all jobs in this workflow inherit least-privilege token access by default.  
For this workflow, the minimal required permission is:

- `contents: read` (needed for `actions/checkout`)

Best single fix without changing functionality:
- Edit `.github/workflows/tf_validate_oraclecloud.yml`
- Insert, near the top-level keys (after `name` is ideal),:

```yaml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed since this is YAML workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
